### PR TITLE
Added businessIdentificationNumber management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ buildNumber.properties
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
 
+# macOS
+.DS_Store
+
 #
 # Misc.
 #

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The plugin doesn't yet integrate with [Avalara CertCapture](http://www.avalara.c
 
 ### Setting a business identification number
 
-For sales in the European Union (EU), a VAT indentification number may be set on an account using a `businessIdentificationNumber` custom field, so that the VAT is calculated accordingly.
+For sales in the European Union (EU), a VAT identification number may be set on an account using a `businessIdentificationNumber` custom field, so that the VAT is calculated accordingly.
 
 See [VAT Transactions](https://developer.avalara.com/avatax/vat-transactions/) for more details.
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ See [Handling tax exempt customers](http://developer.avalara.com/api-docs/design
 
 The plugin doesn't yet integrate with [Avalara CertCapture](http://www.avalara.com/products/certcapture/) to manage exemption certificates, but feel free to [get in touch](https://groups.google.com/forum/#!forum/killbilling-users) to see this feature added.
 
+### Setting a business identification number
+
+For sales in the European Union (EU), a VAT indentification number may be set on an account using a `businessIdentificationNumber` custom field, so that the VAT is calculated accordingly.
+
+See [VAT Transactions](https://developer.avalara.com/avatax/vat-transactions/) for more details.
+
+Note that you should validate the VAT number before yourself, the plugin won't perform any validation. See [VIES](http://ec.europa.eu/taxation_customs/vies/technicalInformation.html) for an EU validation API.
+
 ### Setting tax codes
 
 There are several ways to configure tax codes:

--- a/src/main/java/org/killbill/billing/plugin/avatax/api/AvaTaxTaxCalculator.java
+++ b/src/main/java/org/killbill/billing/plugin/avatax/api/AvaTaxTaxCalculator.java
@@ -61,6 +61,7 @@ public class AvaTaxTaxCalculator extends AvaTaxTaxCalculatorBase {
 
     public static final String PROPERTY_COMPANY_CODE = "companyCode";
     public static final String CUSTOMER_USAGE_TYPE = "customerUsageType";
+    public static final String BUSINESS_IDENTIFICATION_NUMBER = "businessIdentificationNumber";
     public static final String TAX_CODE = "taxCode";
 
     private static final Logger logger = LoggerFactory.getLogger(AvaTaxTaxCalculator.class);
@@ -226,7 +227,7 @@ public class AvaTaxTaxCalculator extends AvaTaxTaxCalculatorBase {
         taxRequest.ExemptionNo = null;
         taxRequest.Discount = BigDecimal.ZERO;
         // Required for VAT
-        taxRequest.BusinessIdentificationNo = null;
+        taxRequest.BusinessIdentificationNo = PluginProperties.findPluginPropertyValue(BUSINESS_IDENTIFICATION_NUMBER, pluginProperties);
         taxRequest.PaymentDate = null;
         taxRequest.PosLaneCode = null;
 

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -1,42 +1,40 @@
-/*! SET storage_engine=INNODB */;
+DROP TABLE IF EXISTS avatax_responses;
+CREATE TABLE avatax_responses (
+  record_id int(11) UNSIGNED NOT NULL auto_increment,
+  kb_account_id char(36) NOT NULL,
+  kb_invoice_id char(36) NOT NULL,
+  kb_invoice_item_ids longtext DEFAULT NULL,
+  doc_code varchar(255) DEFAULT NULL,
+  doc_date datetime DEFAULT NULL,
+  timestamp datetime DEFAULT NULL,
+  total_amount numeric(15,9) DEFAULT NULL,
+  total_discount numeric(15,9) DEFAULT NULL,
+  total_exemption numeric(15,9) DEFAULT NULL,
+  total_taxable numeric(15,9) DEFAULT NULL,
+  total_tax numeric(15,9) DEFAULT NULL,
+  total_tax_calculated numeric(15,9) DEFAULT NULL,
+  tax_date datetime DEFAULT NULL,
+  tax_lines longtext DEFAULT NULL,
+  tax_summary longtext DEFAULT NULL,
+  tax_addresses longtext DEFAULT NULL,
+  result_code varchar(255) DEFAULT NULL,
+  messages longtext DEFAULT NULL,
+  additional_data longtext DEFAULT NULL,
+  created_date datetime NOT NULL,
+  kb_tenant_id char(36) NOT NULL,
+  PRIMARY KEY(record_id)
+) /*! ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_bin */;
+CREATE INDEX avatax_responses_kb_account_id ON avatax_responses(kb_account_id);
+CREATE INDEX avatax_responses_kb_invoice_id ON avatax_responses(kb_invoice_id);
 
-drop table if exists avatax_responses;
-create table avatax_responses (
-  record_id int(11) unsigned not null auto_increment
-, kb_account_id char(36) not null
-, kb_invoice_id char(36) not null
-, kb_invoice_item_ids longtext default null
-, doc_code varchar(255) default null
-, doc_date datetime default null
-, timestamp datetime default null
-, total_amount numeric(15,9) default null
-, total_discount numeric(15,9) default null
-, total_exemption numeric(15,9) default null
-, total_taxable numeric(15,9) default null
-, total_tax numeric(15,9) default null
-, total_tax_calculated numeric(15,9) default null
-, tax_date datetime default null
-, tax_lines longtext default null
-, tax_summary longtext default null
-, tax_addresses longtext default null
-, result_code varchar(255) default null
-, messages longtext default null
-, additional_data longtext default null
-, created_date datetime not null
-, kb_tenant_id char(36) not null
-, primary key(record_id)
-) /*! CHARACTER SET utf8 COLLATE utf8_bin */;
-create index avatax_responses_kb_account_id on avatax_responses(kb_account_id);
-create index avatax_responses_kb_invoice_id on avatax_responses(kb_invoice_id);
-
-drop table if exists avatax_tax_codes;
-create table avatax_tax_codes (
-  record_id int(11) unsigned not null auto_increment
-, product_name varchar(255) not null
-, tax_code varchar(255) not null
-, created_date datetime not null
-, kb_tenant_id char(36) not null
-, primary key(record_id)
-) /*! CHARACTER SET utf8 COLLATE utf8_bin */;
-create index avatax_tax_codes_product_name on avatax_tax_codes(product_name);
-create unique index avatax_tax_codes_product_name_tax_code on avatax_tax_codes(product_name, tax_code);
+DROP TABLE IF EXISTS avatax_tax_codes;
+CREATE TABLE avatax_tax_codes (
+  record_id int(11) unsigned NOT NULL auto_increment,
+  product_name varchar(255) NOT NULL,
+  tax_code varchar(255) NOT NULL,
+  created_date datetime NOT NULL,
+  kb_tenant_id char(36) NOT NULL,
+  PRIMARY KEY(record_id)
+) /*! ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_bin */;
+CREATE INDEX avatax_tax_codes_product_name ON avatax_tax_codes(product_name);
+CREATE UNIQUE INDEX avatax_tax_codes_product_name_tax_code ON avatax_tax_codes(product_name, tax_code);


### PR DESCRIPTION
The business identification number used for EU tax calculations with Avalara was missing, it is now implemented as a custom field on the account (similar to customerUsageType).

The PR also cleans/fixes the DDL SQL as SET storage_engine failed the import on my setup (maybe MySQL 5.7), and SQL syntax was not standard like other KillBill DDLs.