### PR TITLE
api: add option to skip tax calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Set the `customerUsageType` custom field on the account object (e.g. `E` for cha
 
 See [Handling tax exempt customers](https://help.avalara.com/Avalara_AvaTax_Update/Options_for_exempting_customers) for more details.
 
+Note that you can also skip an account entirely by setting the plugin property `AVALARA_SKIP` at runtime (the plugin property value doesn't matter, it just cannot be blank).
+
 ### Setting tax codes
 
 There are several ways to configure tax codes:

--- a/src/main/java/org/killbill/billing/plugin/avatax/api/AvalaraInvoicePluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/avatax/api/AvalaraInvoicePluginApi.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -26,6 +26,7 @@ import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.plugin.api.PluginProperties;
 import org.killbill.billing.plugin.api.invoice.PluginInvoicePluginApi;
 import org.killbill.billing.plugin.avatax.client.AvaTaxClient;
 import org.killbill.billing.plugin.avatax.client.TaxRatesClient;
@@ -38,6 +39,8 @@ import org.killbill.clock.Clock;
 import com.google.common.collect.ImmutableList;
 
 public class AvalaraInvoicePluginApi extends PluginInvoicePluginApi {
+
+    private static final String AVALARA_SKIP = "AVALARA_SKIP";
 
     private final AvaTaxConfigurationHandler avaTaxConfigurationHandler;
     private final TaxRatesConfigurationHandler taxRatesConfigurationHandler;
@@ -68,6 +71,10 @@ public class AvalaraInvoicePluginApi extends PluginInvoicePluginApi {
 
     @Override
     public List<InvoiceItem> getAdditionalInvoiceItems(final Invoice invoice, final boolean dryRun, final Iterable<PluginProperty> properties, final CallContext callContext) {
+        if (PluginProperties.findPluginPropertyValue(AVALARA_SKIP, properties) != null) {
+            return ImmutableList.<InvoiceItem>of();
+        }
+
         final UUID kbTenantId = callContext.getTenantId();
         final AvaTaxClient avaTaxClient = avaTaxConfigurationHandler.getConfigurable(kbTenantId);
         final TaxRatesClient taxRatesClient = taxRatesConfigurationHandler.getConfigurable(kbTenantId);


### PR DESCRIPTION
When the plugin property `AVALARA_SKIP` is set, the plugin calculation is skipped.
