### PR TITLE
Skip adjustment item if originalInvoice reference id is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following properties are optional:
 
 * `org.killbill.billing.plugin.avatax.companyCode`: your default company code (can be passed using the plugin property `companyCode`)
 * `org.killbill.billing.plugin.avatax.commitDocuments`: whether invoices should be committed to Avalara
+* `org.killbill.billing.plugin.avatax.adjustments.lenientMode`, when true Avatax-plugin skips any adjustment items from Invoice for which the previousInvoiceId is not present (i.e. missing) or else leads to IllegalStateException and fails to generate invoice
 
 ### TaxRates API
 

--- a/src/main/java/org/killbill/billing/plugin/avatax/api/AvaTaxTaxCalculator.java
+++ b/src/main/java/org/killbill/billing/plugin/avatax/api/AvaTaxTaxCalculator.java
@@ -216,8 +216,7 @@ public class AvaTaxTaxCalculator extends AvaTaxTaxCalculatorBase {
                                         "Invalid combination of originalInvoiceReferenceCode %s and adjustments %s", originalInvoiceReferenceCode, adjustmentItems);
         } catch (IllegalStateException e) {                                     
             if (skipAnomalousAdjustments) {
-                logger.warn("Returning null tax request instead of throwing IllegalStateException exception for Invalid combination of originalInvoiceReferenceCode {} and adjustments {}",
-                originalInvoiceReferenceCode, adjustmentItems);
+                logger.warn("Ignoring tax request due to inconsistent adjustments: originalInvoiceReferenceCode={}, adjustmentItems={}", originalInvoiceReferenceCode, adjustmentItems);
                 return null;
             } else {
                 throw e;

--- a/src/main/java/org/killbill/billing/plugin/avatax/client/AvaTaxClient.java
+++ b/src/main/java/org/killbill/billing/plugin/avatax/client/AvaTaxClient.java
@@ -50,6 +50,8 @@ public class AvaTaxClient extends HttpClient {
     private final String companyCode;
     private final String sanitizedCompanyCode;
     private final boolean commitDocuments;
+    // When true - skips adjustments which don't have corrrespnding previousInvoiceId
+    private final boolean skipAnomalousAdjustments;
 
     public AvaTaxClient(final Properties properties) throws GeneralSecurityException {
         super(properties.getProperty(AvaTaxActivator.PROPERTY_PREFIX + "url"),
@@ -60,14 +62,19 @@ public class AvaTaxClient extends HttpClient {
               ClientUtils.getBooleanProperty(properties, "strictSSL"),
               MoreObjects.firstNonNull(ClientUtils.getIntegerProperty(properties, "connectTimeout"), 10000),
               MoreObjects.firstNonNull(ClientUtils.getIntegerProperty(properties, "readTimeout"), 60000),
-              MoreObjects.firstNonNull(ClientUtils.getIntegerProperty(properties, "requestTimeout"), 60000));
+              MoreObjects.firstNonNull(ClientUtils.getIntegerProperty(properties, "requestTimeout"), 60000));    
         this.companyCode = properties.getProperty(AvaTaxActivator.PROPERTY_PREFIX + "companyCode", "DEFAULT");
         this.sanitizedCompanyCode = sanitizeCompanyCode(this.companyCode);
         this.commitDocuments = Boolean.parseBoolean(properties.getProperty(AvaTaxActivator.PROPERTY_PREFIX + "commitDocuments"));
+        this.skipAnomalousAdjustments = Boolean.parseBoolean(properties.getProperty(AvaTaxActivator.PROPERTY_PREFIX + "adjustments.lenientMode"));
     }
 
     public String getCompanyCode() {
         return companyCode;
+    }
+
+    public boolean shouldSkipAnomalousAdjustments() {
+        return this.skipAnomalousAdjustments;
     }
 
     public boolean shouldCommitDocuments() {

--- a/src/main/java/org/killbill/billing/plugin/avatax/client/AvaTaxClient.java
+++ b/src/main/java/org/killbill/billing/plugin/avatax/client/AvaTaxClient.java
@@ -50,7 +50,7 @@ public class AvaTaxClient extends HttpClient {
     private final String companyCode;
     private final String sanitizedCompanyCode;
     private final boolean commitDocuments;
-    // When true - skips adjustments which don't have correspnding previousInvoiceId
+    // When true - skips adjustments which don't have corresponding previousInvoiceId
     private final boolean skipAnomalousAdjustments;
 
     public AvaTaxClient(final Properties properties) throws GeneralSecurityException {

--- a/src/main/java/org/killbill/billing/plugin/avatax/client/AvaTaxClient.java
+++ b/src/main/java/org/killbill/billing/plugin/avatax/client/AvaTaxClient.java
@@ -50,7 +50,7 @@ public class AvaTaxClient extends HttpClient {
     private final String companyCode;
     private final String sanitizedCompanyCode;
     private final boolean commitDocuments;
-    // When true - skips adjustments which don't have corrrespnding previousInvoiceId
+    // When true - skips adjustments which don't have correspnding previousInvoiceId
     private final boolean skipAnomalousAdjustments;
 
     public AvaTaxClient(final Properties properties) throws GeneralSecurityException {


### PR DESCRIPTION
There are scenarios like below where adjustment item does not have linked OriginalInvoiceReferenceId -

1. Organization is not taxable and has recurring subscription from 15-15 every month.
2. It was billed on Jan 1 with target date as EOM.
3. Generated Invoice billed it from Dec15-Jan15 as expected with no taxes as its not taxable org.
4. Org A cancels subscription on 4th Jan.
5. Before Next billing i.e. Feb 1, it's decided that Org A must be taxed.
6. Billing on Feb-1 tries to repair to refund amount from 5th Jan to EOM. However Avatax tries to generate adjustment tax item for which Original tax item does not exist because Org was not taxable at that time.
7. This results in illegalStateException in Avatax plugin.

This PR not exactly fixes this but introduces a new plugin config property  "org.killbill.billing.plugin.avatax.adjustments.lenientMode" which if set to true would result in skipping such anomalous adjustment-Item.