### PR TITLE
Changes to fix compilation errors after updating parent pom version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This integration delegates computation of sales taxes to Avalara, which will app
 |          0.6.y |            0.20.z | Legacy REST API |
 |          0.7.y |            0.22.z | Legacy REST API |
 |          0.8.y |            0.22.z | REST API        |
-|          0.9.y |            0.23.z | REST API        |
+|          0.9.y |            0.24.z | REST API        |
 
 We've upgraded numerous dependencies in 0.8.x (required for Java 11 support).
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-8b2bb84-SNAPSHOT</version>
+        <version>0.146.6</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>avatax-plugin</artifactId>
@@ -43,7 +43,6 @@
     <properties>
         <check.fail-spotbugs>true</check.fail-spotbugs>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
-        <killbill-base-plugin.version>5.0.0-14752c2-SNAPSHOT</killbill-base-plugin.version>
         <osgi.private>org.killbill.billing.plugin.avatax.*</osgi.private>
     </properties>
     <dependencies>
@@ -82,27 +81,22 @@
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>testing-mysql-server</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>testing-postgresql-server</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -128,11 +122,6 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.kill-bill.commons</groupId>
-            <artifactId>killbill-metrics-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.billing</groupId>
@@ -181,6 +170,16 @@
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-embeddeddb-mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-metrics-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.testing</groupId>
+            <artifactId>testing-mysql-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/killbill/billing/plugin/avatax/TestInvoiceContext.java
+++ b/src/test/java/org/killbill/billing/plugin/avatax/TestInvoiceContext.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.avatax;
+
+import java.util.List;
+
+import org.joda.time.LocalDate;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.plugin.api.InvoiceContext;
+import org.killbill.billing.plugin.api.PluginCallContext;
+import org.killbill.billing.plugin.avatax.core.AvaTaxActivator;
+import org.killbill.billing.util.callcontext.CallContext;
+
+public class TestInvoiceContext extends PluginCallContext implements InvoiceContext {
+
+    private final LocalDate targetDate;
+    private final Invoice invoice;
+    private final List<Invoice> existingInvoices;
+    private final boolean isDryRun;
+    private final boolean isRescheduled;
+
+    public TestInvoiceContext(final LocalDate targetDate,
+                              final Invoice invoice,
+                              final List<Invoice> existingInvoices,
+                              final boolean isDryRun,
+                              final boolean isRescheduled,
+                              final CallContext context) {
+        super(AvaTaxActivator.PLUGIN_NAME, context.getCreatedDate(), context.getAccountId(), context.getTenantId());
+        this.targetDate = targetDate;
+        this.invoice = invoice;
+        this.existingInvoices = existingInvoices;
+        this.isDryRun = isDryRun;
+        this.isRescheduled = isRescheduled;
+    }
+
+    @Override
+    public LocalDate getTargetDate() {
+        return targetDate;
+    }
+
+    @Override
+    public Invoice getInvoice() {
+        return invoice;
+    }
+
+    @Override
+    public List<Invoice> getExistingInvoices() {
+        return existingInvoices;
+    }
+
+    @Override
+    public boolean isDryRun() {
+        return isDryRun;
+    }
+
+    @Override
+    public boolean isRescheduled() {
+        return isRescheduled;
+    }
+
+}

--- a/src/test/java/org/killbill/billing/plugin/avatax/api/TestTaxRatesInvoicePluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/avatax/api/TestTaxRatesInvoicePluginApi.java
@@ -30,12 +30,14 @@ import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoiceUserApi;
+import org.killbill.billing.invoice.plugin.api.InvoiceContext;
 import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.plugin.TestUtils;
 import org.killbill.billing.plugin.api.PluginCallContext;
 import org.killbill.billing.plugin.avatax.AvaTaxRemoteTestBase;
+import org.killbill.billing.plugin.avatax.TestInvoiceContext;
 import org.killbill.billing.plugin.avatax.core.AvaTaxActivator;
 import org.killbill.billing.plugin.avatax.core.TaxRatesConfigurationHandler;
 import org.killbill.billing.util.callcontext.CallContext;
@@ -55,6 +57,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
     private TaxRatesInvoicePluginApi taxRatesInvoicePluginApi;
     private Account account;
     private CallContext callContext;
+    private InvoiceContext invoiceContext;
 
     @BeforeMethod(groups = "integration")
     public void setUp() throws Exception {
@@ -70,6 +73,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
         account = TestUtils.buildAccount(Currency.USD, "45 Fremont Street", null, "San Francisco", "CA", "94105", "US");
 
         callContext = new PluginCallContext(AvaTaxActivator.PLUGIN_NAME, clock.getUTCNow(), account.getId(), UUID.randomUUID());
+        invoiceContext = new TestInvoiceContext(null, null, null, false, false, callContext);
 
         osgiKillbillAPI = TestUtils.buildOSGIKillbillAPI(account);
         Mockito.when(osgiKillbillAPI.getInvoiceUserApi()).thenReturn(Mockito.mock(InvoiceUserApi.class));
@@ -96,7 +100,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
          */
         final InvoiceItem taxableItem1 = TestUtils.buildInvoiceItem(invoice, InvoiceItemType.EXTERNAL_CHARGE, new BigDecimal("100"), null);
         invoiceItems.add(taxableItem1);
-        List<InvoiceItem> additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, callContext);
+        List<InvoiceItem> additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, invoiceContext).getAdditionalItems();
         // 4 TAX items expected (total $8.63)
         checkTaxes(additionalInvoiceItems, 4, new BigDecimal("8.63"));
 
@@ -106,7 +110,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
          *       $8.63 Tax items (x4)
          */
         invoiceItems.addAll(additionalInvoiceItems);
-        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, callContext);
+        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, invoiceContext).getAdditionalItems();
         checkTaxes(additionalInvoiceItems, 0, BigDecimal.ZERO);
 
         /*
@@ -117,7 +121,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
          */
         final InvoiceItem itemAdjustment2 = TestUtils.buildInvoiceItem(invoice, InvoiceItemType.ITEM_ADJ, new BigDecimal("-50"), taxableItem1.getId());
         invoiceItems.add(itemAdjustment2);
-        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, callContext);
+        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, invoiceContext).getAdditionalItems();
         // 4 TAX items expected (total -$4.32)
         checkTaxes(additionalInvoiceItems, 4, new BigDecimal("-4.32"));
 
@@ -129,7 +133,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
          *      -$4.32 Tax items (x4)
          */
         invoiceItems.addAll(additionalInvoiceItems);
-        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, callContext);
+        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, invoiceContext).getAdditionalItems();
         checkTaxes(additionalInvoiceItems, 0, BigDecimal.ZERO);
 
         /*
@@ -142,7 +146,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
          */
         final InvoiceItem itemAdjustment3 = TestUtils.buildInvoiceItem(invoice, InvoiceItemType.ITEM_ADJ, new BigDecimal("-50"), taxableItem1.getId());
         invoiceItems.add(itemAdjustment3);
-        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, callContext);
+        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, invoiceContext).getAdditionalItems();
         // 4 TAX items expected (total -$4.32)
         // Note: due to rounding, more tax is returned than initially taxed. In case of multiple item adjustments, you might have to return tax manually in Avalara.
         checkTaxes(additionalInvoiceItems, 4, new BigDecimal("-4.32"));
@@ -157,7 +161,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
          *      -$4.32 Tax items (x4)
          */
         invoiceItems.addAll(additionalInvoiceItems);
-        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, callContext);
+        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice, false, pluginProperties, invoiceContext).getAdditionalItems();
         checkTaxes(additionalInvoiceItems, 0, BigDecimal.ZERO);
     }
 
@@ -173,7 +177,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
          */
         final InvoiceItem taxableItem1 = TestUtils.buildInvoiceItem(invoice1, InvoiceItemType.RECURRING, new BigDecimal("100"), null);
         invoiceItems1.add(taxableItem1);
-        List<InvoiceItem> additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice1, false, pluginProperties, callContext);
+        List<InvoiceItem> additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice1, false, pluginProperties, invoiceContext).getAdditionalItems();
         // 4 TAX items expected (total $8.63)
         checkTaxes(additionalInvoiceItems, 4, new BigDecimal("8.63"));
 
@@ -183,7 +187,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
          *       $8.63 Tax items (x4)
          */
         invoiceItems1.addAll(additionalInvoiceItems);
-        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice1, false, pluginProperties, callContext);
+        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice1, false, pluginProperties, invoiceContext).getAdditionalItems();
         checkTaxes(additionalInvoiceItems, 0, BigDecimal.ZERO);
 
         /*
@@ -197,7 +201,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
         invoiceItems2.add(repair2);
         Mockito.when(osgiKillbillAPI.getInvoiceUserApi().getInvoiceByInvoiceItem(Mockito.eq(taxableItem1.getId()), Mockito.<TenantContext>any()))
                .thenReturn(invoice1);
-        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice2, false, pluginProperties, callContext);
+        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice2, false, pluginProperties, invoiceContext).getAdditionalItems();
         // 4 TAX items expected (total -$4.32)
         checkTaxes(additionalInvoiceItems, 4, new BigDecimal("-4.32"));
 
@@ -207,7 +211,7 @@ public class TestTaxRatesInvoicePluginApi extends AvaTaxRemoteTestBase {
          *      -$4.32 Tax items (x4)
          */
         invoiceItems2.addAll(additionalInvoiceItems);
-        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice2, false, pluginProperties, callContext);
+        additionalInvoiceItems = taxRatesInvoicePluginApi.getAdditionalInvoiceItems(invoice2, false, pluginProperties, invoiceContext).getAdditionalItems();
         checkTaxes(additionalInvoiceItems, 0, BigDecimal.ZERO);
     }
 


### PR DESCRIPTION
This PR includes the changes that were made to fix compilation errors that occurred after updating the parent pom version to `0.146.6`.

I would like to highlight a couple of issues:

- In order to get the tests to work, I had to create a new class called [TestInvoiceContext.java](https://github.com/reshmabidikar/killbill-avatax-plugin/blob/5e1d4cbd744f9548dde9f8505b8ec77cbbd077f3/src/test/java/org/killbill/billing/plugin/avatax/TestInvoiceContext.java) and use it in tests (For example [here](https://github.com/reshmabidikar/killbill-avatax-plugin/blob/5e1d4cbd744f9548dde9f8505b8ec77cbbd077f3/src/test/java/org/killbill/billing/plugin/avatax/api/TestTaxRatesInvoicePluginApi.java#L76)). However, I'm wondering if we should move this class to the `plugin-framework` similar to the [PluginCallContext](https://github.com/killbill/killbill-plugin-framework-java/blob/7a7bca1122d95ead9efa1d88e9b6f509e551ce1a/src/main/java/org/killbill/billing/plugin/api/PluginCallContext.java) class?
- After the changes in this PR, there are no compilation errors. However, the plugin does not work (tax item is not created). I debugged the code further and this is what I found:
  - The invoice items related to tax are created properly in the plugin but when the `InvoicePluginDispatcher` tries to retrieve them [here](https://github.com/killbill/killbill/blob/b3223b4ee5eb06bbbfef16dc4196f89757195610/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java#L345), an empty list is returned. 
  - Looking at the plugin code further, the invoice items are computed in [this method](https://github.com/killbill/killbill-avatax-plugin/blob/c06e3bd8132fc32ac4703db5822934b024e0932e/src/main/java/org/killbill/billing/plugin/avatax/api/AvaTaxTaxCalculatorBase.java#L64) which actually returns an `ImmutableList`. Could this be causing the issue (since we have now removed the Guava dependencies from Kill Bill)? 
  - The Hello World plugin includes [sample invoice plugin code](https://github.com/killbill/killbill-hello-world-java-plugin/blob/5349b071a36aaf0e9b1ac5e08b45ea686ed9e6e6/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldInvoicePluginApi.java#L66) which works properly and the additional invoice items are included in the invoice. 